### PR TITLE
Enable scrolling in item catalog list

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,0 +1,26 @@
+## Run the App
+eca start
+
+This command compiles the the code and starts a local webserver with an alma instance including the cloud app at:
+
+http://localhost:4200/institution/45KBDK_KGL
+
+The local webserver tests against KB's Alma Sandbox.
+Alma uses two-factor authentication, and that prevents us from being able to log into alma and use the localhost webservice,
+when we try, we are just sent to Alma Sandbox. We found a little hacky way to access the localhost webserver:
+
+1. Go to http://localhost:4200/institution/45KBDK_KGL
+2. Type in credentials (Alma Sandbox credentials).
+3. You receive a confirmation e-mail. Right-click the link and copy the url into a new tab in the browser. Replace the first
+   part of the link with "http://localhost:4200"
+
+This: https://kbdk-kgl-psb.alma.exlibrisgroup.com/infra/socialLoginRedirect?institute=45KBDK_KGL&jwt=
+Becomes this: http://localhost:4200/infra/socialLoginRedirect?institute=45KBDK_KGL&jwt=
+
+Now you can access the local webserver and find your changes in the cloud app.
+
+## Run the tests
+eca test
+
+## Run the tests with code coverage report
+eca test --code-coverage

--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
 # kb-digitization-cloudapp
 
-## Run the App
-eca start
-
-## Run the tests
-eca test
-
-## Run the tests with code coverage report
-eca test --code-coverage
+The "Digitization addon" lets system administrators in Alma send and receive items for digitization. The cloud app lets
+them type in a barcode or 583 field and this will send a request to the Maestro flow that the item needs to be digitized.
+They can also type in a collection of items with a code like "NKS-4_4737_1" and a list of items will appear to choose from.
 

--- a/cloudapp/src/app/item-list-dialog/item-list-dialog.component.html
+++ b/cloudapp/src/app/item-list-dialog/item-list-dialog.component.html
@@ -6,7 +6,7 @@
         <div *ngFor="let item of data.items; index as i;">
             <mat-radio-button value="{{i}}">
                 <b>Title: </b>{{item.bib_data.title}} <br/>
-                <b>Call number: </b>{{item.holding_data.call_number}}
+                <b>Call number: </b>{{item.holding_data.call_number}}<br/>
                 <b>Description: </b>{{item.item_data.description}}
             </mat-radio-button>
         </div>

--- a/cloudapp/src/app/item-list-dialog/item-list-dialog.component.scss
+++ b/cloudapp/src/app/item-list-dialog/item-list-dialog.component.scss
@@ -4,6 +4,8 @@
 
 .dialog-content {
   padding: 5px;
+  max-height: 500px;
+  overflow-y: auto; /* Enables vertical scrolling */
 }
 
 .dialog-footer {

--- a/cloudapp/src/app/main/main.component.theme.scss
+++ b/cloudapp/src/app/main/main.component.theme.scss
@@ -5,4 +5,16 @@
     padding: 5px;
     font-weight: bolder;
   }
+
+  .mat-radio-label {
+    align-items: flex-start; /* align radio button to top of radio-button-content */
+  }
+
+  .mat-radio-container {
+    margin-right: 5px; /* add some space between radio-button-content and radio-button */
+  }
+
+  .mat-radio-button {
+    margin-bottom: 20px; /* add some space below each radio button item (dialog item) */
+  }
 }


### PR DESCRIPTION
How to test:

- Follow readme to start the application (if this is the first time you might have to also install eca and fetch other npm dependencies)
For eca:
`sudo npm install -g @exlibris/exl-cloudapp-cli` 
Or see https://github.com/ExLibrisGroup/cloudapp-sdk
IntelliJ/terminal guided me through the rest of the npm dependencies that was missing, when attempting to run eca test (I believe).
- You need to chose  the desk: `Atelierbestilling_Håndskrifter og breve_100062`  in the local host Alma and then type `NKS-4_4737_1` for the barcode in the digitilization addon app, click "send" and the window should pop up, with the changes.
- Suggestion - you can switch between the master branch and this PR branch, to see the difference.